### PR TITLE
fix: converted args to numpy.ndarray before input to imshow.

### DIFF
--- a/src/nnpf/visu/visu.py
+++ b/src/nnpf/visu/visu.py
@@ -37,8 +37,17 @@ class ImShow:
         if X is not None and extent is None:
             extent = [X[0].min(), X[0].max(), X[1].min(), X[1].max()]
 
+        def to_numpy_image(img):
+            if isinstance(img, torch.Tensor):
+                return img.detach().cpu().numpy()
+            return img
+        def sanitize_extent(extent):
+            if isinstance(extent, (list, tuple)):
+                return [float(e) if hasattr(e, '__float__') else float(e.item()) for e in extent]
+            return extent
+
         self.ax, self.fig = get_axe_fig(ax, fig)
-        self.graph = self.ax.imshow(self._get_img(img), *args, origin="lower", extent=extent, **kwargs)
+        self.graph = self.ax.imshow(to_numpy_image(self._get_img(img)), *args, origin="lower", extent=sanitize_extent(extent), **kwargs)
 
     def update(self, img):
         self.graph.set_array(self._get_img(img))

--- a/src/nnpf/visu/visu.py
+++ b/src/nnpf/visu/visu.py
@@ -37,17 +37,13 @@ class ImShow:
         if X is not None and extent is None:
             extent = [X[0].min(), X[0].max(), X[1].min(), X[1].max()]
 
-        def to_numpy_image(img):
-            if isinstance(img, torch.Tensor):
-                return img.detach().cpu().numpy()
-            return img
         def sanitize_extent(extent):
             if isinstance(extent, (list, tuple)):
                 return [float(e) if hasattr(e, '__float__') else float(e.item()) for e in extent]
             return extent
 
         self.ax, self.fig = get_axe_fig(ax, fig)
-        self.graph = self.ax.imshow(to_numpy_image(self._get_img(img)), *args, origin="lower", extent=sanitize_extent(extent), **kwargs)
+        self.graph = self.ax.imshow(self._get_img(img), *args, origin="lower", extent=sanitize_extent(extent), **kwargs)
 
     def update(self, img):
         self.graph.set_array(self._get_img(img))
@@ -59,8 +55,10 @@ class ImShow:
         return self.graph
 
     def _get_img(self, img):
-        return img.squeeze().transpose(0, 1)
-
+        img = img.squeeze().transpose(0, 1)
+        if isinstance(img, torch.Tensor):
+            img = img.detach().cpu().numpy()
+        return img
 
 def get_weight(weight_or_module):
     """ Return weight whatever input is the weight or a module """


### PR DESCRIPTION
On Apple Silicon, some arguments of imshow could be an instance of torch.Tensor, and we might have the following error:
```
   self.ax, self.fig = get_axe_fig(ax, fig)
        self.graph = self.ax.imshow(self._get_img(img), *args, origin="lower", extent=extent, **kwargs)

ValueError: object __array__ method not producing an array
```

Therefore, I suggest that we confirm if the arguments of imshow are surely instances of numpy.ndarray.
I understand that this error would not occur on other platform than MacOS.